### PR TITLE
Don't require an Output node to be present

### DIFF
--- a/lib/hasta/emr_job_definition.rb
+++ b/lib/hasta/emr_job_definition.rb
@@ -38,7 +38,11 @@ module Hasta
     end
 
     def output_path
-      @output_path ||= S3URI.parse(emr_node.output_path)
+      if emr_node.output_path
+        @output_path ||= S3URI.parse(emr_node.output_path)
+      end
+
+      @output_path
     end
 
     def env
@@ -74,7 +78,7 @@ module Hasta
     end
 
     def data_sink
-      @data_sink ||= S3DataSink.new(output_path)
+      @data_sink ||= (output_path ? S3DataSink.new(output_path) : InMemoryDataSink.new("EMR Output"))
     end
 
     private

--- a/lib/hasta/emr_node.rb
+++ b/lib/hasta/emr_node.rb
@@ -73,7 +73,9 @@ module Hasta
     end
 
     def output_path
-      @output_path ||= interpolate(attributes[:output_path])
+      if attributes[:output_path]
+        @output_path ||= interpolate(attributes[:output_path])
+      end
     end
 
     def mapper

--- a/lib/hasta/version.rb
+++ b/lib/hasta/version.rb
@@ -1,3 +1,3 @@
 module Hasta
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
@danhodge - Allow EMR activities with no output node specified.  Don't merge this until we've tested on staging.
